### PR TITLE
chore: memoize words in typing effect

### DIFF
--- a/src/components/DynamicTyping.jsx
+++ b/src/components/DynamicTyping.jsx
@@ -1,16 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 
 function DynamicTyping() {
-  const words = [
-    "platforms",
-    "brands", 
-    "experiences",
-    "stories",
-    "interfaces",
-    "tools",
-    "campaigns", 
-    "products"
-  ];
+  const words = useMemo(
+    () => [
+      "platforms",
+      "brands",
+      "experiences",
+      "stories",
+      "interfaces",
+      "tools",
+      "campaigns",
+      "products",
+    ],
+    []
+  );
   
   const [currentWordIndex, setCurrentWordIndex] = useState(0);
   const [displayText, setDisplayText] = useState('');


### PR DESCRIPTION
## Summary
- memoize word list for typing animation to avoid repeated effect executions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894972ede4c83248ed77f2a47517e15